### PR TITLE
Request to update twitter to x icon [Fixes #12]

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "express": "^4.18.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.4.0",
+    "react-icons": "^4.11.0",
     "react-responsive": "^9.0.0-beta.10",
     "sirv": "^2.0.2",
     "vite-plugin-ssr": "^0.4.26"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,9 +1,9 @@
 import {
   FaGithub,
-  FaTwitter,
+  FaXTwitter,
   FaLinkedinIn,
   FaInstagram,
-} from 'react-icons/fa/index';
+} from 'react-icons/fa6';
 
 const Footer = () => (
   <footer className={`text-sm shadow-inner-xs dark:bg-slate-900 bg-slate-100`}>
@@ -37,7 +37,7 @@ const Footer = () => (
           href="https://twitter.com/Razorpay"
           aria-label="Open Razorpay Twitter"
         >
-          <FaTwitter size="1rem" />
+          <FaXTwitter size="1rem" />
         </a>
         <a
           href="https://linkedin.com/company/razorpay"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1598,10 +1598,10 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-icons@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.4.0.tgz#a13a8a20c254854e1ec9aecef28a95cdf24ef703"
-  integrity sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==
+react-icons@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.11.0.tgz#4b0e31c9bfc919608095cc429c4f1846f4d66c65"
+  integrity sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==
 
 react-is@^16.13.1:
   version "16.13.1"


### PR DESCRIPTION
The Twitter logo has been updated recently and hasn't been updated on this site. [Fixes #12]
We will find the new twitter icon in the updated version of react-icon

Old icon
<img width="185" alt="Screenshot 2023-10-13 at 11 38 44 PM" src="https://github.com/razorpay/opensource.razorpay.com/assets/69191344/05f7d152-820a-4f7f-a83d-a80b211f226f">

New icon
<img width="183" alt="Screenshot 2023-10-13 at 11 38 36 PM" src="https://github.com/razorpay/opensource.razorpay.com/assets/69191344/476c521e-7d7e-42cb-a995-54e80608ff4b">
